### PR TITLE
単語とトランスクリプトを連携させる

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,4 +11,8 @@ module ApplicationHelper
   def turbo_stream_flash
   turbo_stream.update "flash", partial: "shared/flash_messages"
   end
+
+  def clean_word(word)
+    word.gsub(/[!.,?]/, '')
+  end
 end

--- a/app/models/transcript.rb
+++ b/app/models/transcript.rb
@@ -1,3 +1,5 @@
 class Transcript < ApplicationRecord
   belongs_to :video
+  has_many :transcript_words
+  has_many :words, through: :transcript_words
 end

--- a/app/models/transcript_word.rb
+++ b/app/models/transcript_word.rb
@@ -1,0 +1,4 @@
+class TranscriptWord < ApplicationRecord
+  belongs_to :transcript
+  belongs_to :word
+end

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -1,8 +1,10 @@
 class Word < ApplicationRecord
-  validates :english_word, presence: true, length: { maximum: 20 }
+  validates :english_word, presence: true, length: { maximum: 30 }
   validates :japanese_meaning, presence: true, length: { maximum: 50 }
 
   belongs_to :user
+  has_many :transcript_words
+  has_many :transcripts, through: :transcript_words
 
   def self.ransackable_attributes(auth_object = nil)
     ["english_word", "japanese_meaning"]

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -3,10 +3,18 @@
 </div>
 
 <div style="height: 300px; overflow-y: auto; background: whitesmoke;">
-  <% @video.transcript.content.split("\n").each do |line| %>
-    <% line.split(" ").each do |word| %>
-      <span class="translated-word" data-original="<%= word %>"><%= word %></span>
+<% @video.transcript.content.split("\n").each do |line| %>
+  <% line.split(" ").each do |word| %>
+    <% cleaned_word = clean_word(word) %>
+    <% if Word.where("LOWER(english_word) = ?", cleaned_word.downcase).exists? %>
+      <% word_record = Word.find_by("LOWER(english_word) = ?", cleaned_word.downcase) %>
+      <div class="tooltip tooltip-warning" data-tip="<%= word_record.japanese_meaning %>">
+        <span class="text-warning font-semibold"><%= word %></span>
+      </div>
+    <% else %>
+      <span><%= word %></span>
     <% end %>
-    <br>
   <% end %>
+  <br>
+<% end %>
 </div>

--- a/db/migrate/20240507021637_create_transcript_words.rb
+++ b/db/migrate/20240507021637_create_transcript_words.rb
@@ -1,0 +1,11 @@
+class CreateTranscriptWords < ActiveRecord::Migration[7.1]
+  def change
+    create_table :transcript_words do |t|
+      t.references :transcript, null: false, foreign_key: true
+      t.references :word, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :transcript_words, [:transcript_id, :word_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_04_082932) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_07_021637) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "transcript_words", force: :cascade do |t|
+    t.bigint "transcript_id", null: false
+    t.bigint "word_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["transcript_id", "word_id"], name: "index_transcript_words_on_transcript_id_and_word_id", unique: true
+    t.index ["transcript_id"], name: "index_transcript_words_on_transcript_id"
+    t.index ["word_id"], name: "index_transcript_words_on_word_id"
+  end
 
   create_table "transcripts", force: :cascade do |t|
     t.text "content"
@@ -55,6 +65,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_04_082932) do
     t.index ["user_id"], name: "index_words_on_user_id"
   end
 
+  add_foreign_key "transcript_words", "transcripts"
+  add_foreign_key "transcript_words", "words"
   add_foreign_key "transcripts", "videos"
   add_foreign_key "words", "users"
 end

--- a/test/fixtures/transcript_words.yml
+++ b/test/fixtures/transcript_words.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  transcript: one
+  word: one
+
+two:
+  transcript: two
+  word: two

--- a/test/models/transcript_word_test.rb
+++ b/test/models/transcript_word_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TranscriptWordTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
[![Image from Gyazo](https://i.gyazo.com/929ead853b09e539ec9c04dc0d02eaee.gif)](https://gyazo.com/929ead853b09e539ec9c04dc0d02eaee)
単語帳に登録してある英単語がトランスクリプト内にあった場合、色をかえてPCならHover、スマホならタップで意味が表示されるように変更。
WordsテーブルとTranscriptsテーブルの中間テーブルを作ることでテーブル同士を繋げた。
```
class Transcript < ApplicationRecord
  belongs_to :video
  has_many :transcript_words
  has_many :words, through: :transcript_words
end

```

```
class Word < ApplicationRecord
  validates :english_word, presence: true, length: { maximum: 30 }
  validates :japanese_meaning, presence: true, length: { maximum: 50 }

  belongs_to :user
  has_many :transcript_words
  has_many :transcripts, through: :transcript_words
```

```
class TranscriptWord < ApplicationRecord
  belongs_to :transcript
  belongs_to :word
end
```
show画面では！ヘルパーを使ってマークなどの特殊文字をなくし、大文字小文字を区別せずに単語の評価を行ように実装。
```
<% @video.transcript.content.split("\n").each do |line| %>
  <% line.split(" ").each do |word| %>
    <% cleaned_word = clean_word(word) %>
    <% if Word.where("LOWER(english_word) = ?", cleaned_word.downcase).exists? %>
      <% word_record = Word.find_by("LOWER(english_word) = ?", cleaned_word.downcase) %>
      <div class="tooltip tooltip-warning" data-tip="<%= word_record.japanese_meaning %>">
        <span class="text-warning font-semibold"><%= word %></span>
      </div>
    <% else %>
      <span><%= word %></span>
    <% end %>
  <% end %>
  <br>
<% end %>
```