### PR TITLE
bug fix

### DIFF
--- a/app/views/words/_form.html.erb
+++ b/app/views/words/_form.html.erb
@@ -6,7 +6,7 @@
     <div>
       <span class="text-red-400 text-xl">*</span>
       <%= f.label :english_word, class: "px-1" %>
-      <%= f.text_field :english_word, autofocus: true, id: "english_word", class: "text-base block w-full px-5 py-3 transition duration-500 ease-in-out transform border border-transparent rounded-lg bg-gray-50 focus:outline-none focus:border-transparent focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-300" %>
+      <%= f.text_field :english_word, id: "english_word", class: "text-base block w-full px-5 py-3 transition duration-500 ease-in-out transform border border-transparent rounded-lg bg-gray-50 focus:outline-none focus:border-transparent focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-300" %>
     </div>
 
     <div>


### PR DESCRIPTION
modalを開いていないのに予測入力の部分だけが表示されてしまうバグを解決。
オートフォーカスをオフにしたら解決。