### PR TITLE
単語登録バグ修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!
-  before_action :set_word
 
   protected
 
@@ -17,9 +16,5 @@ class ApplicationController < ActionController::Base
 
  def after_sign_out_path_for(resource)
    new_user_session_path # ログアウト後に遷移するpathを設定
- end
-
- def set_word
-  @word = Word.new
  end
 end

--- a/app/views/words/_error_messages.html.erb
+++ b/app/views/words/_error_messages.html.erb
@@ -1,7 +1,7 @@
-<% if @word.errors.any? %>
+<% if word.errors.any? %>
   <div id="error_explanation" class="text-red-600">
     <ul>
-    <% @word.errors.full_messages.each do |message| %>
+    <% word.errors.full_messages.each do |message| %>
       <div class="flash text-sm text-red-800 border border-red-300 rounded-lg bg-red-50 flex items-center p-4 mb-4"><i class="fa-solid fa-circle-info"></i><%= message %></div>
     <% end %>
     </ul>

--- a/app/views/words/_form.html.erb
+++ b/app/views/words/_form.html.erb
@@ -1,7 +1,7 @@
 <div id="error_messages">
-  <%= render 'words/error_messages'%>
+  <%= render 'words/error_messages', word: word %>
 </div>
-<%= form_with(model: @word, local: true) do |f| %>
+<%= form_with(model: word, local: true) do |f| %>
   <div class="font-bold text-lg text-center text-[#172c66]">
     <div>
       <span class="text-red-400 text-xl">*</span>

--- a/app/views/words/_new.html.erb
+++ b/app/views/words/_new.html.erb
@@ -1,6 +1,6 @@
 <div class="flex items-center justify-center">
     <div class="space-y-5 text-center">
       <h1 class="font-bold text-2xl text-[#001858]">Add A New Word</h1>
-      <%= render "words/form" %>
+      <%= render "words/form", word: Word.new %>
     </div>
 </div>

--- a/app/views/words/edit.html.erb
+++ b/app/views/words/edit.html.erb
@@ -6,7 +6,7 @@
               </div>
             </div>
     <div class="space-y-5">
-    <%= render "form" %>
+    <%= render "words/form", word: @word %>
     <div class="delete_button flex justify-end text-[#172c66]">
       <%= link_to word_path(@word), data: {turbo_method: :delete, turbo_confirm: 'Are you sure?'} do %>
         <i class="fa-regular fa-trash-can fa-xl"></i>


### PR DESCRIPTION
単語編集画面、単語復習画面から単語登録をしようとすると、初期値が入ってしまうバグを修正。
レンダリングを
<%= render "words/form", word: Word.new %>
のようにしてwordの値を動的に変更することで対応。