### PR TITLE
単語復習機能のスタイル

### DIFF
--- a/app/views/words/random.html.erb
+++ b/app/views/words/random.html.erb
@@ -5,14 +5,15 @@
 </div>
 <div class="text-center text-[#172c66]">
 <% if @word %>
-  <div class="word-card">
-    <h2 class="text-2xl font-semibold my-5"><%= @word.english_word %></h2>
+  <div class="word-card px-6">
+    <h2 class="text-3xl font-semibold my-5"><%= @word.english_word %></h2>
     <p class="text-xl font-semibold mb-5"><%= @word.part_of_speech %></p>
-    <div class="text-xl font-semibold mb-5" id="meaning" style="display: none;">
-      <p><%= simple_format(@word.meaning) %></p>
-      <p class="text-lg mt-2"><%= simple_format(@word.example) %></p>
-    </div>
     <i class="hover:cursor-pointer fa-solid fa-volume-high fa-xl" id="speak-button"></i>
+    <div class="text-lg font-semibold my-5" id="meaning" style="display: none;">
+      <p><%= simple_format(@word.meaning) %></p>
+      <br>
+      <p><%= simple_format(@word.example) %></p>
+    </div>
     <div class="flex items-center justify-center mt-5">
       <button id="show-buttons" class="border-2 border-[#172c66] bg-white rounded-3xl p-2" onclick="document.getElementById('meaning').style.display = 'block'">Meaning</button>
     </div>


### PR DESCRIPTION
長文で登録した時に横のマージンがあった方がいいので追加。
スピーカーボタンが移動しないように変更。
細かいスタイル変更。