### PR TITLE
プロフィール作成・学習継続記録

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,7 @@ end
 gem "devise", "~> 4.9"
 gem "dockerfile-rails", ">= 1.6", :group => :development
 gem 'dotenv-rails'
+gem 'friendly_id', '~> 5.4.0'
 gem 'gon'
 gem 'httparty'
 gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
       net-http
+    friendly_id (5.4.2)
+      activerecord (>= 4.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     gon (6.4.0)
@@ -389,6 +391,7 @@ DEPENDENCIES
   dockerfile-rails (>= 1.6)
   dotenv-rails
   factory_bot_rails
+  friendly_id (~> 5.4.0)
   gon
   high_voltage
   httparty

--- a/app/controllers/pronunciation_scores_controller.rb
+++ b/app/controllers/pronunciation_scores_controller.rb
@@ -2,6 +2,7 @@ class PronunciationScoresController < ApplicationController
   def create
     @pronunciation_score = current_user.pronunciation_scores.new(pronunciation_score_params)
     if @pronunciation_score.save
+      Activity.create(user: current_user, action_type: 'pronunciation_check')
       render json: @pronunciation_score, status: :created
     else
       render json: @pronunciation_score.errors, status: :unprocessable_entity

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,23 @@
+class UsersController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+    @user = User.find(params[:id])
+  end
+
+  def profile
+    @user = current_user
+    @ranking = fetch_ranking.first(10)
+  end
+
+  private
+
+    def fetch_ranking
+      users_with_continuous_days = User.all.map do |user|
+        { user:, continuous_days: user.continuous_days }
+      end
+
+      users_with_continuous_days.select { |entry| (entry[:continuous_days]).positive? }
+                                .sort_by { |entry| -entry[:continuous_days] }
+    end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   before_action :authenticate_user!
 
   def show
-    @user = User.find(params[:id])
+    @user = User.friendly.find(params[:id])
   end
 
   def profile

--- a/app/controllers/words_controller.rb
+++ b/app/controllers/words_controller.rb
@@ -11,6 +11,7 @@ class WordsController < ApplicationController
   def create
     @word = current_user.words.build(word_params)
     if @word.save
+      Activity.create(user: current_user, action_type: 'word_registration')
       flash.notice = "New word has been saved."
       redirect_to request.referer || word_path
     else
@@ -67,6 +68,8 @@ class WordsController < ApplicationController
     when 'hard'
       @word.update(review_status: 'hard', next_review_date: Time.zone.today) # 何度も表示
     end
+
+    Activity.create(user: current_user, action_type: 'review_completed')
     redirect_to random_words_path
   end
 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,0 +1,3 @@
+class Activity < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  extend FriendlyId
+  friendly_id :username, use: :slugged
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: %i[google_oauth2]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ApplicationRecord
   has_many :pronunciation_texts, through: :pronunciation_scores, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :liked_videos, through: :likes, source: :video
+  has_many :activities, dependent: :destroy
   validates :username, presence: true, length: { minimum: 2 }
   validates :password, presence: true, on: :create
 
@@ -35,5 +36,23 @@ class User < ApplicationRecord
       .group('users.id, users.username')
       .order('overall_average DESC')
       .limit(limit)
+  end
+
+  def continuous_days
+    return 0 if activities.empty?
+
+    days_with_activity = activities.select(:created_at).distinct.pluck(:created_at).map(&:to_date).uniq
+    days_with_activity.sort!
+    return 1 if days_with_activity.length == 1
+
+    continuous_days = 1
+
+    days_with_activity.each_cons(2) do |a, b|
+      return 0 unless b == a + 1
+
+      continuous_days += 1
+    end
+
+    continuous_days
   end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -32,6 +32,12 @@
             <span>Pronunciation Test</span>
           <% end %>
         </li>
+        <li>
+          <%= link_to user_profile_path, class:"flex items-center gap-x-2.5 py-2 px-2.5 text-sm rounded-lg hover:bg-gray-100", data: { turbo: false } do %>
+            <i class="fa-solid fa-user fa-xl" style="min-width: 1.5em; text-align: center;"></i>
+            <span>Profile</span>
+          <% end %>
+        </li>
         <li class="fixed bottom-2">
           <div class="dropdown dropdown-top">
             <div tabindex="0" role="button" class="flex items-center py-5 px-3 text-sm rounded-lg hover:bg-gray-100">
@@ -85,6 +91,11 @@
       <div class="hs-tooltip inline-block [--placement:right]">
         <%= link_to pronunciation_texts_path, class:"flex items-center gap-x-3.5 py-4 px-2.5 text-sm rounded-lg hover:bg-gray-100", data: { turbo: false } do %>
           <i class="fa-solid fa-microphone fa-xl"></i>
+        <% end %>
+      </div>
+      <div class="hs-tooltip inline-block [--placement:right]">
+        <%= link_to user_profile_path, class:"flex items-center gap-x-3.5 py-4 px-2.5 text-sm rounded-lg hover:bg-gray-100", data: { turbo: false } do %>
+          <i class="fa-solid fa-user fa-xl"></i>
         <% end %>
       </div>
       <div class="dropdown dropdown-top fixed bottom-2">
@@ -165,6 +176,11 @@
       <%= link_to pronunciation_texts_path, class:"flex items-center gap-x-3.5 py-2 px-3 text-sm rounded-lg hover:bg-gray-100", data: { turbo: false } do %>
         <i class="fa-solid fa-microphone fa-xl"></i>
       <% end %>
+    </div>
+    <div class="hs-tooltip inline-block [--placement:right]">
+        <%= link_to user_profile_path, class:"flex items-center gap-x-3.5 py-4 px-2.5 text-sm rounded-lg hover:bg-gray-100", data: { turbo: false } do %>
+          <i class="fa-solid fa-user fa-xl"></i>
+        <% end %>
     </div>
     <div class="grid"><!-- 左端の透明なスペース --></div>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -168,7 +168,7 @@
       <% end %>
     </div>
     <div class="hs-tooltip inline-block [--placement:right]">
-      <label for="my_modal" class="hover:cursor-pointer flex items-center gap-x-3.5 py-2 px-2.5 text-sm rounded-lg hover:bg-gray-100">
+      <label for="my_modal" class="hover:cursor-pointer flex items-center gap-x-3.5 py-2 px-3 text-sm rounded-lg hover:bg-gray-100">
         <i class="fa-regular fa-square-plus fa-xl"></i>
       </label>
     </div>
@@ -178,7 +178,7 @@
       <% end %>
     </div>
     <div class="hs-tooltip inline-block [--placement:right]">
-        <%= link_to user_profile_path, class:"flex items-center gap-x-3.5 py-4 px-2.5 text-sm rounded-lg hover:bg-gray-100", data: { turbo: false } do %>
+        <%= link_to user_profile_path, class:"flex items-center gap-x-3.5 py-2 px-3 text-sm rounded-lg hover:bg-gray-100", data: { turbo: false } do %>
           <i class="fa-solid fa-user fa-xl"></i>
         <% end %>
     </div>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -1,0 +1,74 @@
+<div class="flex justify-center mt-5">
+  <h1 class="text-3xl font-semibold text-[#001858]" >Profile</h1>
+</div>
+
+<div class="my-5 mx-10 text-[#001858] flex justify-between items-center">
+  <div class="text-left">
+    <h1 class="text-2xl font-semibold" ><%= @user.username %></h1>
+    <p class="text-sm">Joined <%= @user.created_at.strftime("%B %Y") %></p>
+  </div>
+  <div class="text-right">
+    <%= link_to edit_user_registration_path do %>
+      <i class="fa-solid fa-gear fa-xl"></i>
+    <% end %>
+  </div>
+</div>
+
+<div class="border-t-2 border-grey-200">
+  <h2 class="text-2xl font-semibold text-[#001858] mx-10 mt-5">Learning Record</h2>
+  <h2 class="text-[#001858] mx-10 mb-3">学習記録</h2>
+</div>
+
+<div class="grid md:grid-cols-2 min-[320px]:grid-cols-1 my-3 mx-10 gap-4 justify-center">
+  <div class="text-center border border-grey-200 rounded-2xl px-5 py-3 text-[#001858]">
+    <h2 class="font-semibold">Consecutive study days</h2>
+    <h2 class="mb-3 text-xs">連続学習日数</h2>
+    <div class="flex items-center text-center justify-center space-x-8">
+      <i class="fa-solid fa-fire fa-2xl text-[#ff8906]"></i>
+      <p class="font-semibold">
+        <span class="text-2xl"><%= @user.continuous_days %></span> day(s)
+      </p>
+    </div>
+  </div>
+  <div class="text-center border border-grey-200 rounded-2xl px-5 py-3 text-[#001858]">
+    <h2 class="font-semibold">Registered word count</h2>
+    <h2 class="mb-3 text-xs">単語登録数</h2>
+    <div class="flex items-center text-center justify-center space-x-5">
+      <i class="fa-solid fa-graduation-cap fa-2xl text-[#078080]"></i>
+      <p class="font-semibold">
+        <span class="text-2xl"><%= @user.words.count %></span> word(s)
+      </p>
+    </div>
+  </div>
+</div>
+
+<div class="mx-10 my-5">
+  <h2 class="text-2xl font-semibold text-[#001858]">Learning Streak Ranking</h2>
+  <h2 class="text-[#001858]">連続学習記録ランキング</h2>
+</div>
+
+<div class="w-3/4 mx-auto flex justify-center items-center text-[#172c66] font-semibold">
+  <table class="table mx-auto text-center">
+    <thead>
+      <tr class="text-[#001858]">
+        <th class="bg-[#ffd803] border">Rank</th>
+        <th class="bg-[#ffd803] border">User</th>
+        <th class="bg-[#ffd803] border">Continuous Days</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @ranking.each_with_index do |entry, index| %>
+        <tr>
+          <td class="border px-4 py-2">
+            <%= index + 1 %>
+            <% if index + 1 == 1 %>🥇<% elsif index + 1 == 2 %>🥈<% elsif index + 1 == 3 %>🥉<% end %>
+          </td>
+          <td class="border px-4 py-2">
+            <%= link_to entry[:user].username, user_path(entry[:user]) %>
+          </td>
+          <td class="border px-4 py-2"><%= entry[:continuous_days] %> day(s)</td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,43 @@
+<div class="fixed lg:left-64 md:left-20 md:top-2 min-[320px]:bottom-20">
+  <%= button_to "javascript:history.back()", method: :get, data: {turbo: false}, class: "rounded-full h-11 w-11 bg-transparent border border-gray-300 text-[#172c66] hover:bg-gray-100 ml-2" do %>
+    <i class="fa-solid fa-angles-left"></i>
+  <% end %>
+</div>
+<div class="flex justify-center mt-5">
+  <h1 class="text-3xl font-semibold text-[#001858]"><%= @user.username %>'s Profile</h1>
+</div>
+
+<div class="my-5 mx-10 text-[#001858] flex justify-between items-center">
+  <div class="text-left">
+    <h1 class="text-2xl font-semibold" ><%= @user.username %></h1>
+    <p class="text-sm">Joined <%= @user.created_at.strftime("%B %Y") %></p>
+  </div>
+</div>
+
+<div class="border-t-2 border-grey-200">
+  <h2 class="text-2xl font-semibold text-[#001858] mx-10 mt-5">Learning Record</h2>
+  <h2 class="text-[#001858] mx-10 mb-3">学習記録</h2>
+</div>
+
+<div class="grid md:grid-cols-2 min-[320px]:grid-cols-1 my-3 mx-10 gap-4 justify-center">
+  <div class="text-center border border-grey-200 rounded-2xl px-5 py-3 text-[#001858]">
+    <h2 class="font-semibold">Consecutive study days</h2>
+    <h2 class="mb-3 text-xs">連続学習日数</h2>
+    <div class="flex items-center text-center justify-center space-x-8">
+      <i class="fa-solid fa-fire fa-2xl text-[#ff8906]"></i>
+      <p class="font-semibold">
+        <span class="text-2xl"><%= @user.continuous_days %></span> day(s)
+      </p>
+    </div>
+  </div>
+  <div class="text-center border border-grey-200 rounded-2xl px-5 py-3 text-[#001858]">
+    <h2 class="font-semibold">Registered word count</h2>
+    <h2 class="mb-3 text-xs">単語登録数</h2>
+    <div class="flex items-center text-center justify-center space-x-5">
+      <i class="fa-solid fa-graduation-cap fa-2xl text-[#078080]"></i>
+      <p class="font-semibold">
+        <span class="text-2xl"><%= @user.words.count %></span> word(s)
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -7,7 +7,7 @@
     <h1><%= @video.title %></h1>
 </div>
 <div class="flex justify-center items-center md:mt-5">
-  <iframe class="min-[320px]:w-full md:w-[640px] aspect-video" src="https://www.youtube-nocookie.com/embed/<%= @video.video_id %>?autoplay=0&controls=1&cc_lang_pref=en&cc_load_policy=0&disablekb=1&modestbranding=1&rel=0&color=white&fs=0&iv_load_policy=3" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"></iframe>
+  <iframe id="player" class="min-[320px]:w-full md:w-[640px] aspect-video" src="https://www.youtube-nocookie.com/embed/<%= @video.video_id %>?enablejsapi=1&autoplay=0&controls=1&cc_lang_pref=en&cc_load_policy=0&disablekb=1&modestbranding=1&rel=0&color=white&fs=0&iv_load_policy=3" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"></iframe>
 </div>
 
   <div class="flex justify-center items-center mt-3 mb-1 text-[#172c66]">
@@ -90,3 +90,38 @@
     </div>
 <%= javascript_include_tag 'voice_recording', defer: true %>
 <%= javascript_include_tag 'translator', defer: true %>
+<script src="https://www.youtube.com/iframe_api"></script>
+<script>
+  let player;
+  function onYouTubeIframeAPIReady() {
+    console.log("YouTube IFrame API is ready");
+    player = new YT.Player('player', {
+      events: {
+        'onReady': onPlayerReady,
+        'onStateChange': onPlayerStateChange
+      }
+    });
+  }
+
+  function onPlayerReady(event) {
+    console.log("Player is ready");
+  }
+
+  function onPlayerStateChange(event) {
+    console.log("Player state changed:", event.data);
+    if (event.data === YT.PlayerState.PLAYING) {
+      console.log("video started");
+      // 動画が再生されたときの処理
+      fetch('/track_shadowing', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': '<%= form_authenticity_token %>'
+        },
+        body: JSON.stringify({ event: 'video_played' })
+      })
+      .then(response => response.json())
+      .then(data => console.log(data));
+    }
+  }
+</script>

--- a/app/views/words/_form.html.erb
+++ b/app/views/words/_form.html.erb
@@ -6,13 +6,13 @@
     <div>
       <span class="text-red-400 text-xl">*</span>
       <%= f.label :english_word, class: "px-1" %>
-      <%= f.text_field :english_word, id: "english_word", placeholder: "登録する英単語", class: "font-normal text-base block w-full px-5 py-3 transition duration-500 ease-in-out transform border border-transparent rounded-lg bg-gray-50 focus:outline-none focus:border-transparent focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-300" %>
+      <%= f.text_field :english_word, placeholder: "登録する英単語", class: "font-normal text-base block w-full px-5 py-3 transition duration-500 ease-in-out transform border border-transparent rounded-lg bg-gray-50 focus:outline-none focus:border-transparent focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-300" %>
     </div>
 
     <div>
       <span class="text-red-400 text-xl">*</span>
       <%= f.label :meaning, "Meaning", class: "px-1" %>
-      <%= f.text_area :meaning, id: "meaning", placeholder: "英単語の意味", class: "font-normal text-base block w-full px-5 py-3 transition duration-500 ease-in-out transform border border-transparent rounded-lg bg-gray-50 focus:outline-none focus:border-transparent focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-300" %>
+      <%= f.text_area :meaning, placeholder: "英単語の意味", class: "font-normal text-base block w-full px-5 py-3 transition duration-500 ease-in-out transform border border-transparent rounded-lg bg-gray-50 focus:outline-none focus:border-transparent focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-300" %>
     </div>
 
     <div>
@@ -25,7 +25,7 @@
 
     <div>
       <%= f.label :example, "Example sentence", class: "px-1" %>
-      <%= f.text_area :example, id: "example", placeholder: "例文", class: "font-normal text-base block w-full px-5 py-3 transition duration-500 ease-in-out transform border border-transparent rounded-lg bg-gray-50 focus:outline-none focus:border-transparent focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-300" %>
+      <%= f.text_area :example, placeholder: "例文", class: "font-normal text-base block w-full px-5 py-3 transition duration-500 ease-in-out transform border border-transparent rounded-lg bg-gray-50 focus:outline-none focus:border-transparent focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-300" %>
     </div>
 
     <div class="flex space-x-3 justify-center">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
     passwords: 'users/passwords'
   }
 
+  get 'profile', to: 'users#profile', as: 'user_profile'
+
   resources :rankings, only: [:index]
   resources :pronunciation_scores, only: [:create, :index, :show]
   resources :pronunciation_texts, only: [:index]
@@ -24,4 +26,6 @@ Rails.application.routes.draw do
   resources :videos, only: [:index, :show] do
     resources :likes, only: [:create, :destroy]
   end
+  post '/track_shadowing', to: 'videos#track_shadowing'
+  resources :users, only: [:show]
 end

--- a/db/migrate/20240706071541_create_activities.rb
+++ b/db/migrate/20240706071541_create_activities.rb
@@ -1,0 +1,10 @@
+class CreateActivities < ActiveRecord::Migration[7.1]
+  def change
+    create_table :activities do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :action_type
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240707043734_add_slug_to_users.rb
+++ b/db/migrate/20240707043734_add_slug_to_users.rb
@@ -1,0 +1,6 @@
+class AddSlugToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :slug, :string
+    add_index :users, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_06_071541) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_07_043734) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -83,8 +83,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_06_071541) do
     t.string "username", null: false
     t.string "provider"
     t.string "uid"
+    t.string "slug"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["slug"], name: "index_users_on_slug", unique: true
   end
 
   create_table "videos", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_29_081625) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_06_071541) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "activities", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "action_type"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_activities_on_user_id"
+  end
 
   create_table "likes", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -103,6 +111,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_29_081625) do
     t.index ["user_id"], name: "index_words_on_user_id"
   end
 
+  add_foreign_key "activities", "users"
   add_foreign_key "likes", "users"
   add_foreign_key "likes", "videos"
   add_foreign_key "pronunciation_scores", "pronunciation_texts"

--- a/spec/system/words_spec.rb
+++ b/spec/system/words_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe "Words", type: :system do
     visit words_path
     all('label[for="my_modal"]').first.click
 
-    fill_in "english_word", with: "test"
-    fill_in "meaning", with: "a procedure intended to establish the quality, performance, or reliability of something"
+    fill_in "English word", with: "test"
+    fill_in "Meaning", with: "a procedure intended to establish the quality, performance, or reliability of something"
     select "noun (名詞)", from: "Part of speech"
-    fill_in "example", with: "This is a test sentence."
+    fill_in "Example", with: "This is a test sentence."
 
     click_button "Save Word"
 
@@ -29,7 +29,7 @@ RSpec.describe "Words", type: :system do
       visit edit_word_path(word)
       expect(page).to have_current_path(edit_word_path(word))
       within("[data-form-type='edit']") do
-        fill_in "english_word", with: "Updated Word"
+        fill_in "English word", with: "Updated Word"
         click_button "Save Word"
       end
 
@@ -40,7 +40,7 @@ RSpec.describe "Words", type: :system do
     it "shows validation errors" do
       visit edit_word_path(word)
       within("[data-form-type='edit']") do
-        fill_in "english_word", with: ""
+        fill_in "English word", with: ""
         click_button "Save Word"
       end
       expect(page).to have_content("can't be blank")

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/factories/activities.rb
+++ b/test/factories/activities.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :activity do
+    user { nil }
+    action_type { "MyString" }
+  end
+end

--- a/test/models/activity_test.rb
+++ b/test/models/activity_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ActivityTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
- [x] ユーザーのプロフィールを作成
- [x] アクティビティテーブルを作成し、学習継続日数の記録
- [x] 学習記録の可視化
- [x] 継続日数のランキング化
- [x] 他のユーザーの学習記録を閲覧可能に
- [x] Users/showのURLをFriendlyId導入しUsernameで作成
- [x] ナビゲーションバーの微調整 

[![Image from Gyazo](https://i.gyazo.com/f4eb1c19f1a901e6dd6725b2b4debe84.png)](https://gyazo.com/f4eb1c19f1a901e6dd6725b2b4debe84)

備考
app/views/words/_form.html.erbに関しては、コンソールでIssueが出ていたので修正。
その変更に伴うRspecコード修正。
