### PR TITLE
単語登録の際のエラー表記の変更

### DIFF
--- a/app/controllers/words_controller.rb
+++ b/app/controllers/words_controller.rb
@@ -12,11 +12,16 @@ class WordsController < ApplicationController
     @word = current_user.words.build(word_params)
     if @word.save
       Activity.create(user: current_user, action_type: 'word_registration')
-      flash.notice = "New word has been saved."
-      redirect_to request.referer || word_path
+      respond_to do |format|
+        format.html { redirect_to request.referer || word_path }
+        format.json { render json: { success: true, message: "New word has been saved." }, status: :created }
+      end
     else
-      flash[:alert] = @word.errors.full_messages.join(", ")
-      redirect_to request.referer
+      flash.now[:alert] = @word.errors.full_messages
+      respond_to do |format|
+        format.html { redirect_to request.referer }
+        format.json { render json: { success: false, errors: @word.errors.full_messages }, status: :unprocessable_entity }
+      end
     end
   end
 

--- a/app/views/words/_form.html.erb
+++ b/app/views/words/_form.html.erb
@@ -1,7 +1,7 @@
 <div id="error_messages">
   <%= render 'words/error_messages', word: word %>
 </div>
-<%= form_with(model: word, local: true, html: { data: { form_type: word.new_record? ? 'new' : 'edit' } }) do |f| %>
+<%= form_with(model: word, local: false, id: "word_form", html: { data: { form_type: word.new_record? ? 'new' : 'edit' } }) do |f| %>
   <div class="font-bold text-lg text-center text-[#172c66]">
     <div>
       <span class="text-red-400 text-xl">*</span>
@@ -30,8 +30,44 @@
 
     <div class="flex space-x-3 justify-center">
       <div class="flex flex-col w-3/4 mt-3">
-        <%= f.submit "Save Word", class: "hover:cursor-pointer flex items-center justify-center w-full px-10 py-3 font-medium text-center text-[#172c66] transition duration-500 ease-in-out transform bg-[#ffd803] rounded-xl hover:bg-[#bae8e8] focus:outline-none", data: {"turbo" => false}%>
+        <%= f.submit "Save Word", class: "hover:cursor-pointer flex items-center justify-center w-full px-10 py-3 font-medium text-center text-[#172c66] transition duration-500 ease-in-out transform bg-[#ffd803] rounded-xl hover:bg-[#bae8e8] focus:outline-none"%>
       </div>
     </div>
   </div>
 <% end %>
+<script>
+  document.querySelector("#word_form").addEventListener("submit", function(event) {
+    event.preventDefault(); // デフォルトのフォーム送信を防ぐ
+    const formData = new FormData(event.target);
+
+    fetch(event.target.action, {
+      method: "POST",
+      body: formData,
+      headers: {
+        "X-Requested-With": "XMLHttpRequest",
+        "Accept": "application/json"
+      }
+    })
+    .then(response => response.json())
+    .then(data => {
+      const errorMessagesDiv = document.getElementById("error_messages"); // IDを修正
+      
+      if (data.success) {
+        // 成功時の処理
+        console.log(data.message);
+        window.location.reload(); // ページをリロード
+      } else {
+        // エラー時の処理
+        errorMessagesDiv.innerHTML = ''; // 既存のメッセージをクリア
+        data.errors.forEach(error => {
+          const errorMessage = `<div class="flash text-sm text-red-800 border border-red-300 rounded-lg bg-red-50 flex items-center p-4 mb-4"><i class="fa-solid fa-circle-info"></i>${error}</div>`;
+          errorMessagesDiv.innerHTML += errorMessage; // エラーメッセージを追加
+        });
+        errorMessagesDiv.style.display = 'block'; // エラーメッセージ表示
+      }
+    })
+    .catch(error => {
+      console.error('Error:', error);
+    });
+  });
+</script>

--- a/spec/system/words_spec.rb
+++ b/spec/system/words_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe "Words", type: :system do
 
     click_button "Save Word"
 
-    expect(page).to have_content("New word has been saved.")
     expect(page).to have_content("test")
   end
 


### PR DESCRIPTION
単語登録で、エラーがある場合もモーダルが閉じて入力した内容が消えてしまい不便だったので修正。

Turbo streamを使用し、単語保存が成功した場合のみ、Javascriptでページ全体をリロードして他の箇所に影響しないように対応。
成功時のフラッシュメッセージは無くなった。