### PR TITLE
単語編集画面のフォームを別に作成

### DIFF
--- a/app/views/words/_edit_form.html.erb
+++ b/app/views/words/_edit_form.html.erb
@@ -1,0 +1,35 @@
+<div>
+  <%= render 'words/error_messages', word: word %>
+</div>
+<%= form_with(model: word, local: true, html: { data: { form_type: word.new_record? ? 'new' : 'edit' } }) do |f| %>  <div class="font-bold text-lg text-center text-[#172c66]">
+    <div>
+      <span class="text-red-400 text-xl">*</span>
+      <%= f.label :english_word, class: "px-1" %>
+      <%= f.text_field :english_word, placeholder: "登録する英単語", class: "english_word font-normal text-base block w-full px-5 py-3 transition duration-500 ease-in-out transform border border-transparent rounded-lg bg-gray-50 focus:outline-none focus:border-transparent focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-300" %>
+    </div>
+
+    <div>
+      <span class="text-red-400 text-xl">*</span>
+      <%= f.label :meaning, "Meaning", class: "px-1" %>
+      <%= f.text_area :meaning, placeholder: "英単語の意味", class: "meaning font-normal text-base block w-full px-5 py-3 transition duration-500 ease-in-out transform border border-transparent rounded-lg bg-gray-50 focus:outline-none focus:border-transparent focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-300" %>
+    </div>
+
+    <div>
+      <span class="text-red-400 text-xl">*</span>
+      <%= f.label :part_of_speech, class: "px-1" %><br>
+      <div class="font-normal text-base text-center block w-full transform border border-transparent rounded-lg">
+        <%= f.select :part_of_speech, options_for_select([["品詞を選択", ""],"noun (名詞)", "pronoun (代名詞)", "verb (動詞)", "adjective (形容詞)", "adverb (副詞)", "preposition (前置詞)", "conjunction (接続詞)", "interjection (間投詞)"], f.object.part_of_speech), {}, { class: "block ease-in-out transition duration-500 bg-gray-50 w-full px-5 py-4 rounded-lg focus:outline-none focus:border-transparent focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-300" } %>
+      </div>
+    </div>
+
+    <div>
+      <%= f.label :example, "Example sentence", class: "px-1" %>
+      <%= f.text_area :example, placeholder: "例文", class: "font-normal text-base block w-full px-5 py-3 transition duration-500 ease-in-out transform border border-transparent rounded-lg bg-gray-50 focus:outline-none focus:border-transparent focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-300" %>
+    </div>
+
+    <div class="flex space-x-3 justify-center">
+      <div class="flex flex-col w-3/4 mt-3">
+      <%= f.submit "Save Word", class: "hover:cursor-pointer flex items-center justify-center w-full px-10 py-3 font-medium text-center text-[#172c66] transition duration-500 ease-in-out transform bg-[#ffd803] rounded-xl hover:bg-[#bae8e8] focus:outline-none", data: {"turbo" => false}%>      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/words/edit.html.erb
+++ b/app/views/words/edit.html.erb
@@ -11,7 +11,7 @@
               </div>
             </div>
     <div class="space-y-5">
-    <%= render "words/form", word: @word %>
+    <%= render "words/edit_form", word: @word %>
     <div class="delete_button flex justify-end text-[#172c66]">
       <%= link_to word_path(@word), data: {turbo_method: :delete, turbo_confirm: 'Are you sure?'} do %>
         <i class="fa-regular fa-trash-can fa-xl"></i>


### PR DESCRIPTION
これまでは単語新規登録と編集のフォームを同じにしていたが、新規登録画面でのみTurboをオンにしたいのでフォームを別に切り分ける。